### PR TITLE
Feat: 영화 리뷰 토큰으로 인증 처리

### DIFF
--- a/cookie/src/pages/MovieReviewFeed.jsx
+++ b/cookie/src/pages/MovieReviewFeed.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import axios from "axios";
+import axiosInstance from "../api/auth/axiosInstance";
 
 const PageWrapper = styled.div`
     width: 90%;
@@ -82,8 +83,8 @@ const MovieReviewFeed = ({ movieId }) => {
   useEffect(() => {
     const fetchReviews = async () => {
       try {
-        const response = await axios.get(
-          `http://localhost:8080/api/reviews/movie/${movieId}`
+        const response = await axiosInstance.get(
+          `http://localhost:8080/api/{movies}/${movieId}/reviews`
         );
         setReviews(response.data);
         setFilteredReviews(response.data);

--- a/cookie/src/pages/MovieReviewForm.jsx
+++ b/cookie/src/pages/MovieReviewForm.jsx
@@ -179,9 +179,7 @@ const MovieReviewForm = () => {
     navigate(-1); // 이전 페이지로 돌아가기
   };
 
-  const handleSubmit = async () => {
-    const userId = 1; // 사용자 ID를 여기에 설정 (로그인된 사용자 ID 필요)
-  
+  const handleSubmit = async () => {  
     const payload = {
       movieId: 1,
       movieScore,

--- a/cookie/src/pages/MovieReviewForm.jsx
+++ b/cookie/src/pages/MovieReviewForm.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import { useLocation, useNavigate } from "react-router-dom";
 import axios from "axios";
+import axiosInstance from "../api/auth/axiosInstance";
 
 const PageWrapper = styled.div`
     width: 90%;
@@ -189,8 +190,8 @@ const MovieReviewForm = () => {
     };
   
     try {
-      const response = await axios.post(
-        `http://localhost:8080/api/reviews/${userId}`,
+      const response = await axiosInstance.post(
+        `http://localhost:8080/api/reviews/`,
         payload
       );
       if (response.status === 200) {

--- a/cookie/src/pages/ReviewDetail.jsx
+++ b/cookie/src/pages/ReviewDetail.jsx
@@ -7,6 +7,7 @@ import ReviewContentSection from "../components/mypage/ReviewContentSection";
 import ReviewTextSection from "../components/mypage/ReviewTextSection";
 import FooterSection from "../components/mypage/FooterSection";
 import { toast } from "react-hot-toast";
+import axiosInstance from "../api/auth/axiosInstance";
 
 const Container = styled.div`
   padding: 20px;
@@ -153,7 +154,7 @@ const ReviewDetail = () => {
   useEffect(() => {
     const fetchReviewData = async () => {
       try {
-        const response = await axios.get(
+        const response = await axiosInstance.get(
           `http://localhost:8080/api/reviews/${reviewId}`
         );
         const review = response.data.response; // API 응답 데이터
@@ -176,8 +177,8 @@ const ReviewDetail = () => {
     if (!newComment.trim()) return;
 
     try {
-      const response = await axios.post(
-        `http://localhost:5173/api/reviews/${reviewId}/comments/${userId}`,
+      const response = await axiosInstance.post(
+        `http://localhost:5173/api/reviews/${reviewId}/comments`,
         { comment: newComment } // POST 요청 본문
       );
 

--- a/cookie/src/pages/ReviewFeed.jsx
+++ b/cookie/src/pages/ReviewFeed.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import axiosInstance from "../api/auth/axiosInstance";
 
 const ReviewFeedWrapper = styled.div`
   width: 100%;
@@ -223,7 +224,7 @@ useEffect(() => {
 
       console.log(`Fetching page ${page}...`);
 
-      const response = await axios.get(endpoint, {
+      const response = await axiosInstance.get(endpoint, {
         params: { page, size: 10 },
       });
 

--- a/cookie/src/pages/ReviewForm.jsx
+++ b/cookie/src/pages/ReviewForm.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
+import axiosInstance from "../api/auth/axiosInstance";
 
 const FormWrapper = styled.div`
   width: 90%;
@@ -148,8 +149,8 @@ const ReviewForm = ({ movieTitle }) => {
     };
   
     try {
-      const response = await axios.post(
-        `http://localhost:8080/api/reviews/${userId}`,
+      const response = await axiosInstance.post(
+        `http://localhost:8080/api/reviews`,
         payload
       );
       if (response.status === 200) {


### PR DESCRIPTION
## 🍿 연관된 이슈

> #91

## 🎬 작업 내용

> 1. 영화 리뷰 토큰으로 인증 처리
영화 리뷰 피드, 영화 스포일러 리뷰 피드, 특정 영화의 리뷰 피드, 리뷰 등록, 리뷰 상세보기

> 2. 모든 피드에서 로그인하지 않은 사용자 구분 처리를 해서, 비로그인 일때는 likedByUser 필드를 false로 반환하도록 했습니다.

## 추가 전달 사항
> 1. 특정 영화 리뷰 피드에서 일반/스포일러 엔드포인트 구분이 필요해요
> 2. 리뷰 댓글에 로그인한 유저가 작성한 댓글인 경우 수정/삭제 토글 추가가 필요해요 -> 구분을 위해 userId를 추가로 반환하겠습니다.
> 3. 리뷰 피드들 같은 경우, 좋아요 구분이 필요하므로 헤더에 토큰을 보내되, 서버에서 구분하여 처리하도록 했어요(작업 내용 2번)
> 4. 마이페이지에서 리뷰 상세보기, 특정 영화에서 리뷰 상세보기 페이지 UI를 통일하고 마이페이지에서 리뷰 상세보기를 할 때는 수정/삭제할 수 있도록 해야할 거 같아요 api 매핑도 추가해야할 거 같습니다.
> 5. 리뷰 좋아요 색깔 구분도 필요해보여요


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 추가 전달 사항에 대한 코멘트 부탁드립니다~

